### PR TITLE
백준/DFS/도넛행성

### DIFF
--- a/src/main/java/com/study/javaalgorithm/showmethecode/real/도넛행성/Main.java
+++ b/src/main/java/com/study/javaalgorithm/showmethecode/real/도넛행성/Main.java
@@ -3,69 +3,83 @@ package com.study.javaalgorithm.showmethecode.real.도넛행성;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.Arrays;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Queue;
+import java.util.StringTokenizer;
 
+/**
+ * https://www.acmicpc.net/problem/27211
+ */
 public class Main {
     private static final BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
     private final static int[] dx = { -1, 1, 0, 0 };
     private final static int[] dy = { 0, 0, -1, 1 };
 
     public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(reader.readLine());
         // 데이터 초기화
-        String[] input = reader.readLine().split(" ");
-        int N = Integer.parseInt(input[0]); // 상하
-        int M = Integer.parseInt(input[1]); // 좌우
-
-        List<Spot> queue = new LinkedList<>();
+        int N = Integer.parseInt(st.nextToken()); // 상하
+        int M = Integer.parseInt(st.nextToken()); // 좌우
 
         int[][] planet = new int[N][M];
+        boolean[][] visited = new boolean[N][M];
 
         for (int i = 0; i < N; i++) {
-            String[] line = reader.readLine().split(" ");
+            st = new StringTokenizer(reader.readLine());
             for (int j = 0; j < M; j++) {
-                planet[i][j] = Integer.parseInt(line[j]);
-                if (planet[i][j] == 0) {
-                    queue.add(new Spot(i, j));
+                planet[i][j] = Integer.parseInt(st.nextToken());
+                if (planet[i][j] != 0) {
+                    visited[i][j] = true;
                 }
             }
         }
 
-        // 구역찾기
-        boolean[][] visited = new boolean[N][M];
         int count = 0;
-        while (!queue.isEmpty()) {
-            Spot spot = queue.get(0);
-            queue.remove(0);
-
-            if (!visited[spot.x][spot.y]) {
-                dfs(planet, spot.x, spot.y, visited, queue);
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (visited[i][j]) {
+                    continue;
+                }
                 count += 1;
+                Queue<Spot> queue = new LinkedList<>();
+                queue.add(new Spot(i, j));
+
+                while (!queue.isEmpty()) {
+                    Spot spot = queue.poll();
+
+                    for (int direction = 0; direction < 4; direction++) {
+                        int nextX = getNext(dx, direction, spot.x, planet.length);
+                        int nextY = getNext(dy, direction, spot.y, planet[0].length);
+
+                        if (!visited[nextX][nextY] && planet[nextX][nextY] == 0) {
+                            queue.add(new Spot(nextX, nextY));
+                            visited[nextX][nextY] = true;
+                        }
+                    }
+                }
             }
         }
 
         System.out.println(count);
     }
 
-    private static void dfs(int[][] planet, int x, int y, boolean[][] visited, List<Spot> queue) {
+    // bfs
+    private static void visitSameArea(int[][] planet, int x, int y, boolean[][] visited, Queue<Spot> queue) {
 //        System.out.printf("(%d, %d)\n", x, y);
         visited[x][y] = true;
 //        System.out.println(Arrays.deepToString(visited));
 
         for (int i = 0; i < 4; i++) {
-            int nextX = getNextX(dx, i, x, planet.length);
-            int nextY = getNextX(dy, i, y, planet[0].length);
+            int nextX = getNext(dx, i, x, planet.length);
+            int nextY = getNext(dy, i, y, planet[0].length);
 
             if (!visited[nextX][nextY] && planet[nextX][nextY] == 0) {
-                queue.remove(new Spot(x, y));
-                dfs(planet, nextX, nextY, visited, queue);
+                visitSameArea(planet, nextX, nextY, visited, queue);
             }
         }
     }
 
-    private static int getNextX(int[] direction, int i, int spot, int size) {
+    private static int getNext(int[] direction, int i, int spot, int size) {
         int next = direction[i] + spot;
         if (size == next) {
             next = 0;


### PR DESCRIPTION
https://www.acmicpc.net/problem/27211

원티드에서 진행한 '쇼미더코드'의 문제 중 하나다.

단순한 DFS 에서 배열 끝과 끝에서 이동할 수 있다는 특징이 추가된 유형으로 파악했다.  

## 접근 1

0 으로 이어진 `구역의 개수` 를 찾는 문제이기 때문에 배열 전체를 순회하되 이미 방문한 공간이라면 패스, 방문하지 않은 공간이면 dfs를 실행하도록 구현했다.

문제는 당시 시험 수행중이라 구체적인 코드가 기억은 안나지만 `시간초과`가 나서 멘붕과 고민에 빠졌었다.  
내 기억엔 dfs 인데 재귀가 함께 구성되있었다. 접근은 좋았으나 구현에 문제가 있었을 것 같다.

## 접근 2

시험이 끝나고 문제가 공개됐고 다시 풀면서 queue 형태로 풀었다.  
그 때 2중 for문으로 모든 배열의 요소에 방문하는 것이 찜찜하여 초기화할 때 queue 에 0인 스팟을 저장하도록 구현했는데 또 시간초과가 났다.  
방문하게될 타겟을 줄인다고 생각했는데 그 과정에서 queue의 요소를 삭제하는 로직이 존재했다.
아무래도 queue에서 요소를 찾아가며 삭제하는 것을 계속 반복하니 비효율적이었던 것 같다.

## 접근 3

결국 queue를 사용하되 다시 2중 for문으로 모든 배열의 요소에 방문하도록 바꿨는데 성공하였다.  

## 마무리

가끔은 단순하게 가는 것이 가장 효율적일 때가 있다..